### PR TITLE
Add jekyll to preview examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /node_modules
 .docker-project
 yarn-error.log
+Gemfile.lock
+/_jekyll/_site

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+gem 'jekyll', '~> 3.4.0'
+
+require 'rbconfig'
+if RbConfig::CONFIG['target_os'] =~ /darwin(1[0-3])/i
+  gem 'rb-fsevent', '<= 0.9.4'
+end

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,18 @@
+# Change this to the name of your theme
+name: Vanilla boilerplate theme - Examples
+
+# Change this URL to reflect the name of your theme
+baseurl: /vanilla-boilerplate-theme
+
+# Makes pretty (descriptive) permalinks. See Jekyll docs for alternatives.
+permalink: pretty
+
+# Keep Jekyll directories out of the way
+plugins_dir:  _jekyll/_plugins
+layouts_dir:  _jekyll/_layouts
+destination: _jekyll/_site
+
+# Exclude metadata and development time dependencies (like Grunt plugins)
+exclude: ["*.md", "*.scss", "node_modules", "package.json", "Gemfile", "Gemfile.lock", "gulpfile.js", "gulp", "LICENSE"]
+
+port: 4001

--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <meta charset="utf-8"/>
+         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>{% if page.title %} {{ page.title }} | {% endif %} {{ site.name }}</title>
+        {% if site.env == 'development' %}
+          <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/build/css/build.css" />
+        {% else %}
+          <link rel="stylesheet" type="text/css" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.css" />
+        {% endif %}
+    </head>
+
+    <body>
+      <div style="margin:1rem">
+       {{ content }}
+     </div>
+    </body>
+</html>

--- a/_jekyll/_plugins/environment_variables.rb
+++ b/_jekyll/_plugins/environment_variables.rb
@@ -1,0 +1,13 @@
+# Plugin to add environment variables to the `site` object in Liquid templates
+
+module Jekyll
+
+  class EnvironmentVariablesGenerator < Generator
+
+    def generate(site)
+      site.config['env'] = ENV['JEKYLL_ENV'] || 'production'
+    end
+
+  end
+
+end

--- a/docs/en/patterns/example.md
+++ b/docs/en/patterns/example.md
@@ -1,0 +1,3 @@
+---
+title: Examples
+---

--- a/examples/patterns/example.html
+++ b/examples/patterns/example.html
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Example
+category: _patterns
+---
+
+<div class="p-example">
+  hello world
+</div>

--- a/gulp/jekyll.js
+++ b/gulp/jekyll.js
@@ -1,0 +1,7 @@
+var gulp = require('gulp');
+var shell = require('gulp-shell');
+
+// Watch tasks
+gulp.task('jekyll:serve', shell.task([
+  'JEKYLL_ENV=development bundle exec jekyll serve'
+]));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,11 +18,13 @@ wrench.readdirSyncRecursive('./gulp').filter(function(file) {
 gulp.task('help', function() {
   console.log('develop - Watch sass files and generate unminified CSS for development');
   console.log('test  - Lint Sass');
+  console.log('jekyll  - Run gulp develop with Jekyll instance to demo examples');
   console.log('build  - Lint Sass files and generate minified CSS for production');
 });
 
 /* Gulp default task list */
 gulp.task('default', ['help']);
 gulp.task('develop', ['watch', 'sass:develop']);
+gulp.task('jekyll', ['watch', 'sass:develop', 'jekyll:serve']);
 gulp.task('test', ['lint:sass']);
 gulp.task('build', ['lint:sass', 'sass:build']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,13 +18,13 @@ wrench.readdirSyncRecursive('./gulp').filter(function(file) {
 gulp.task('help', function() {
   console.log('develop - Watch sass files and generate unminified CSS for development');
   console.log('test  - Lint Sass');
-  console.log('jekyll  - Run gulp develop with Jekyll instance to demo examples');
+  console.log('start  - Run gulp develop with Jekyll instance to demo examples');
   console.log('build  - Lint Sass files and generate minified CSS for production');
 });
 
 /* Gulp default task list */
 gulp.task('default', ['help']);
 gulp.task('develop', ['watch', 'sass:develop']);
-gulp.task('jekyll', ['watch', 'sass:develop', 'jekyll:serve']);
+gulp.task('start', ['watch', 'sass:develop', 'jekyll:serve']);
 gulp.task('test', ['lint:sass']);
 gulp.task('build', ['lint:sass', 'sass:build']);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+---
+layout: default
+title: Home
+---
+
+<!-- Header -->
+<div class="p-strip">
+    <div class="row">
+      <div class="12-col">
+        <h1>{{ site.name }}</h1>
+        <hr />
+      </div>
+    </div>
+</div>
+
+<div class="p-strip">
+    <div class="row">
+        <div class="col-4">
+            <h3>Base</h3>
+            <nav>
+              <ul class="p-list">
+                  {% for page in site.pages %}
+                      {% if page.url contains '/base/' %}
+                      <li>
+                          <a href="{{ page.url | prepend:site.baseurl }}" class="p-link--soft">{{ page.title }}</a>
+                      </li>
+                      {% endif %}
+                  {% endfor %}
+              </ul>
+            </nav>
+        </div>
+        <div class="col-4">
+            <h3>Patterns</h3>
+            <nav>
+                <ul class="p-list">
+                  {% for page in site.pages %}
+                      {% if page.url contains '/patterns/' %}
+                      <li>
+                          <a href="{{ page.url | prepend:site.baseurl }}" class="p-link--soft">{{ page.title }}</a>
+                      </li>
+                      {% endif %}
+                  {% endfor %}
+                </ul>
+            </nav>
+        </div>
+        <div class="col-4">
+            <h3>Utilities</h3>
+            <nav>
+                <ul class="p-list">
+                    {% for page in site.pages %}
+                        {% if page.url contains '/utilities/' %}
+                        <li>
+                            <a href="{{ page.url | prepend:site.baseurl }}" class="p-link--soft">{{ page.title }}</a>
+                        </li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </nav>
+        </div>
+    </div>
+</div>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "es6-promise": "^4.0.5",
     "gulp-autoprefixer": "3.1.1",
-    "gulp-cache": "0.4.5",
+    "gulp-cache": "0.4.X",
     "gulp-clean": "^0.3.2",
     "gulp-cssnano": "^2.1.2",
     "gulp-notify": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "es6-promise": "^4.0.5",
     "gulp-autoprefixer": "3.1.1",
-    "gulp-cache": "0.4.X",
+    "gulp-cache": "0.4.6",
     "gulp-clean": "^0.3.2",
     "gulp-cssnano": "^2.1.2",
     "gulp-notify": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
   "dependencies": {
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
+    "gulp-shell": "^0.6.3",
     "gulp-util": "^3.0.8",
+    "node-sass": "^4.5.2",
     "vanilla-framework": "^1.1.x"
   }
 }


### PR DESCRIPTION
## Done

- Added Jekyll to provide site to showcase examples

## QA

- Pull code
- Run `gulp jekyll`
- View example site at [http://127.0.0.1:4001/vanilla-boilerplate-theme/](http://127.0.0.1:4001/vanilla-boilerplate-theme/)

Fixes #3 